### PR TITLE
Add multiprecision bitfield [SyncWith: marshalling#32]

### DIFF
--- a/include/nil/crypto3/marshalling/multiprecision/processing/detail/size_to_type.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/processing/detail/size_to_type.hpp
@@ -1,0 +1,67 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017-2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2020-2021 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_PROCESSING_SIZE_TO_TYPE_DETAIL_HPP
+#define CRYPTO3_MARSHALLING_PROCESSING_SIZE_TO_TYPE_DETAIL_HPP
+
+#include <nil/crypto3/multiprecision/number.hpp>
+
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace processing {
+                namespace detail {
+                    /// @cond SKIP_DOC
+
+                    using namespace multiprecision;
+
+                    template<bool IsSigned>
+                    constexpr cpp_integer_type select_magnitude_type() {
+                        if constexpr (IsSigned) {
+                            return signed_magnitude;
+                        } else {
+                            return unsigned_magnitude;
+                        }
+                    }
+
+                    template<bool IsChecked>
+                    constexpr cpp_int_check_type select_checked_type() {
+                        if constexpr (IsChecked) {
+                            return checked;
+                        } else {
+                            return unchecked;
+                        }
+                    }
+
+                    /// @endcond
+
+                }    // namespace detail
+            }    // namespace processing
+        }    // namespace marshalling
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_MARSHALLING_PROCESSING_SIZE_TO_TYPE_DETAIL_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/processing/detail/size_to_type.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/processing/detail/size_to_type.hpp
@@ -28,7 +28,6 @@
 
 #include <nil/crypto3/multiprecision/number.hpp>
 
-
 namespace nil {
     namespace crypto3 {
         namespace marshalling {
@@ -59,9 +58,9 @@ namespace nil {
                     /// @endcond
 
                 }    // namespace detail
-            }    // namespace processing
-        }    // namespace marshalling
-    }    // namespace crypto3
+            }        // namespace processing
+        }            // namespace marshalling
+    }                // namespace crypto3
 }    // namespace nil
 
 #endif    // CRYPTO3_MARSHALLING_PROCESSING_SIZE_TO_TYPE_DETAIL_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp
@@ -1,0 +1,60 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017-2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2020-2021 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_PROCESSING_SIZE_TO_TYPE_HPP
+#define CRYPTO3_MARSHALLING_PROCESSING_SIZE_TO_TYPE_HPP
+
+#include <nil/crypto3/multiprecision/number.hpp>
+
+#include <nil/crypto3/marshalling/multiprecision/processing/detail/size_to_type.hpp>
+
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace processing {
+                /// @cond SKIP_DOC
+
+                template<std::size_t BitLength, bool IsSigned = false, bool IsChecked = false>
+                struct size_to_type {
+                    using type = multiprecision::number<
+                        multiprecision::cpp_int_backend<
+                            BitLength,
+                            BitLength,
+                            detail::select_magnitude_type<IsSigned>(),
+                            detail::select_checked_type<IsChecked>(),
+                            void
+                        >
+                    >;
+                };
+
+                /// @endcond
+
+            }    // namespace processing
+        }    // namespace marshalling
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_MARSHALLING_PROCESSING_SIZE_TO_TYPE_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp
@@ -30,7 +30,6 @@
 
 #include <nil/crypto3/marshalling/multiprecision/processing/detail/size_to_type.hpp>
 
-
 namespace nil {
     namespace crypto3 {
         namespace marshalling {
@@ -40,21 +39,15 @@ namespace nil {
                 template<std::size_t BitLength, bool IsSigned = false, bool IsChecked = false>
                 struct size_to_type {
                     using type = multiprecision::number<
-                        multiprecision::cpp_int_backend<
-                            BitLength,
-                            BitLength,
-                            detail::select_magnitude_type<IsSigned>(),
-                            detail::select_checked_type<IsChecked>(),
-                            void
-                        >
-                    >;
+                        multiprecision::cpp_int_backend<BitLength, BitLength, detail::select_magnitude_type<IsSigned>(),
+                                                        detail::select_checked_type<IsChecked>(), void>>;
                 };
 
                 /// @endcond
 
             }    // namespace processing
-        }    // namespace marshalling
-    }    // namespace crypto3
+        }        // namespace marshalling
+    }            // namespace crypto3
 }    // namespace nil
 
 #endif    // CRYPTO3_MARSHALLING_PROCESSING_SIZE_TO_TYPE_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp
@@ -1,0 +1,187 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017-2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2020-2021 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_FIXED_BIT_LENGTH_HPP
+#define CRYPTO3_MARSHALLING_FIXED_BIT_LENGTH_HPP
+
+#include <nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp>
+
+#include <limits>
+
+#include <nil/marshalling/status_type.hpp>
+
+#include <nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp>
+#include <nil/crypto3/marshalling/multiprecision/processing/integral.hpp>
+
+
+namespace nil {
+    namespace marshalling {
+        namespace types {
+            namespace adapter {
+
+                template<std::size_t TLen, typename TBase>
+                class fixed_bit_length<
+                    TLen,
+                    TBase,
+                    std::enable_if_t<
+                        nil::crypto3::multiprecision::is_number<typename TBase::value_type>::value
+                        && nil::crypto3::multiprecision::backends::is_fixed_precision<typename TBase::value_type::backend_type>::value
+                    >
+                > : public TBase {
+
+                    using base_impl_type = TBase;
+                    using base_serialized_type = typename base_impl_type::serialized_type;
+
+                    static const std::size_t _bit_length = TLen;
+                    static_assert(0 < _bit_length, "Bit length is expected to be greater than 0");
+                    static_assert(_bit_length <= std::numeric_limits<base_serialized_type>::digits, "The provided length limit is too big");
+
+                    static const std::size_t byte_length
+                        = nil::marshalling::processing::bit_size_to_byte_size<_bit_length>::value;
+
+                    static constexpr bool is_signed = std::numeric_limits<base_serialized_type>::is_signed;
+                    // Multiprecision has no support for serialization signed values yet
+                    static_assert(!is_signed, "Signed base class for fixed_bit_length is not supported");
+
+                public:
+                    using value_type = typename base_impl_type::value_type;
+                    using serialized_type = typename crypto3::marshalling::processing::size_to_type<_bit_length, is_signed>::type;
+
+                    using endian_type = typename base_impl_type::endian_type;
+
+                    fixed_bit_length() = default;
+
+                    explicit fixed_bit_length(const value_type &val) : base_impl_type(val) {
+                    }
+
+                    fixed_bit_length(const fixed_bit_length &) = default;
+
+                    fixed_bit_length(fixed_bit_length &&) = default;
+
+                    fixed_bit_length &operator=(const fixed_bit_length &) = default;
+
+                    fixed_bit_length &operator=(fixed_bit_length &&) = default;
+
+                    static constexpr std::size_t length() {
+                        return bit_length() / 8 + ((bit_length() % 8) ? 1 : 0);;
+                    }
+
+                    static constexpr std::size_t min_length() {
+                        return length();
+                    }
+
+                    static constexpr std::size_t max_length() {
+                        return length();
+                    }
+
+                    static constexpr std::size_t bit_length() {
+                        return _bit_length;
+                    }
+
+                    static constexpr std::size_t min_bit_length() {
+                        return bit_length();
+                    }
+
+                    static constexpr std::size_t max_bit_length() {
+                        return bit_length();
+                    }
+
+                    static constexpr serialized_type to_serialized(value_type val) {
+                        serialized_type serialized = static_cast<serialized_type>(base_impl_type::to_serialized(val));
+                        if constexpr (is_signed) {
+                            if (val < 0) {
+                                crypto3::multiprecision::bit_set(
+                                    serialized,
+                                    bit_length()-1
+                                );
+                            } else {
+                                crypto3::multiprecision::bit_unset(
+                                    serialized,
+                                    bit_length()-1
+                                );
+                            }
+                        }
+                        return serialized;
+                    }
+
+                    static constexpr value_type from_serialized(serialized_type val) {
+                        value_type deserialized = base_impl_type::from_serialized(val);
+                        if constexpr (is_signed) {
+                            if (crypto3::multiprecision::bit_test(deserialized, bit_length()-1)) {
+                                value_type mask = value_type(-1) << bit_length();
+                                return deserialized | mask;
+                            } else {
+                                return deserialized;
+                            }
+                        } else {
+                            return deserialized;
+                        }
+                    }
+
+                    template<typename TIter>
+                    nil::marshalling::status_type read(TIter &iter, std::size_t size) {
+                        if (size < length()) {
+                            return nil::marshalling::status_type::not_enough_data;
+                        }
+
+                        read_no_status(iter);
+                        return nil::marshalling::status_type::success;
+                    }
+
+                    template<typename TIter>
+                    void read_no_status(TIter &iter) {
+                        serialized_type serializedValue =
+                            crypto3::marshalling::processing::read_data<
+                                serialized_type,
+                                typename base_impl_type::endian_type
+                            >(iter, _bit_length);
+                        base_impl_type::value() = from_serialized(serializedValue);
+                    }
+
+                    template<typename TIter>
+                    nil::marshalling::status_type write(TIter &iter, std::size_t size) const {
+                        if (size < length()) {
+                            return nil::marshalling::status_type::buffer_overflow;
+                        }
+
+                        write_no_status(iter);
+                        return nil::marshalling::status_type::success;
+                    }
+
+                    template<typename TIter>
+                    void write_no_status(TIter &iter) const {
+                        crypto3::marshalling::processing::write_data<
+                            _bit_length,
+                            typename base_impl_type::endian_type
+                        >(to_serialized(base_impl_type::value()), iter);
+                    }
+                };
+
+            }    // namespace adapter
+        }    // namespace types
+    }    // namespace marshalling
+}    // namespace nil
+
+#endif    // CRYPTO3_MARSHALLING_FIXED_BIT_LENGTH_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp
@@ -54,14 +54,11 @@ namespace nil {
                     static const std::size_t _bit_length = TLen;
                     static_assert(0 < _bit_length, "Bit length is expected to be greater than 0");
                     static_assert(_bit_length <= std::numeric_limits<base_serialized_type>::digits,
-                                  "The provided length limit is too big");
-
-                    static const std::size_t byte_length =
-                        nil::marshalling::processing::bit_size_to_byte_size<_bit_length>::value;
+                                  "The provided length is too big");
 
                     static constexpr bool is_signed = std::numeric_limits<base_serialized_type>::is_signed;
                     // Multiprecision has no support for serialization signed values yet
-                    static_assert(!is_signed, "Signed base class for fixed_bit_length is not supported");
+                    static_assert(!is_signed, "Signed base class for multiprecision fixed_bit_length is not supported");
 
                 public:
                     using value_type = typename base_impl_type::value_type;

--- a/include/nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp
@@ -35,7 +35,6 @@
 #include <nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp>
 #include <nil/crypto3/marshalling/multiprecision/processing/integral.hpp>
 
-
 namespace nil {
     namespace marshalling {
         namespace types {
@@ -45,21 +44,20 @@ namespace nil {
                 class fixed_bit_length<
                     TLen,
                     TBase,
-                    std::enable_if_t<
-                        nil::crypto3::multiprecision::is_number<typename TBase::value_type>::value
-                        && nil::crypto3::multiprecision::backends::is_fixed_precision<typename TBase::value_type::backend_type>::value
-                    >
-                > : public TBase {
+                    std::enable_if_t<nil::crypto3::multiprecision::is_number<typename TBase::value_type>::value &&
+                                     nil::crypto3::multiprecision::backends::is_fixed_precision<
+                                         typename TBase::value_type::backend_type>::value>> : public TBase {
 
                     using base_impl_type = TBase;
                     using base_serialized_type = typename base_impl_type::serialized_type;
 
                     static const std::size_t _bit_length = TLen;
                     static_assert(0 < _bit_length, "Bit length is expected to be greater than 0");
-                    static_assert(_bit_length <= std::numeric_limits<base_serialized_type>::digits, "The provided length limit is too big");
+                    static_assert(_bit_length <= std::numeric_limits<base_serialized_type>::digits,
+                                  "The provided length limit is too big");
 
-                    static const std::size_t byte_length
-                        = nil::marshalling::processing::bit_size_to_byte_size<_bit_length>::value;
+                    static const std::size_t byte_length =
+                        nil::marshalling::processing::bit_size_to_byte_size<_bit_length>::value;
 
                     static constexpr bool is_signed = std::numeric_limits<base_serialized_type>::is_signed;
                     // Multiprecision has no support for serialization signed values yet
@@ -67,7 +65,8 @@ namespace nil {
 
                 public:
                     using value_type = typename base_impl_type::value_type;
-                    using serialized_type = typename crypto3::marshalling::processing::size_to_type<_bit_length, is_signed>::type;
+                    using serialized_type =
+                        typename crypto3::marshalling::processing::size_to_type<_bit_length, is_signed>::type;
 
                     using endian_type = typename base_impl_type::endian_type;
 
@@ -85,7 +84,8 @@ namespace nil {
                     fixed_bit_length &operator=(fixed_bit_length &&) = default;
 
                     static constexpr std::size_t length() {
-                        return bit_length() / 8 + ((bit_length() % 8) ? 1 : 0);;
+                        return bit_length() / 8 + ((bit_length() % 8) ? 1 : 0);
+                        ;
                     }
 
                     static constexpr std::size_t min_length() {
@@ -112,15 +112,9 @@ namespace nil {
                         serialized_type serialized = static_cast<serialized_type>(base_impl_type::to_serialized(val));
                         if constexpr (is_signed) {
                             if (val < 0) {
-                                crypto3::multiprecision::bit_set(
-                                    serialized,
-                                    bit_length()-1
-                                );
+                                crypto3::multiprecision::bit_set(serialized, bit_length() - 1);
                             } else {
-                                crypto3::multiprecision::bit_unset(
-                                    serialized,
-                                    bit_length()-1
-                                );
+                                crypto3::multiprecision::bit_unset(serialized, bit_length() - 1);
                             }
                         }
                         return serialized;
@@ -129,7 +123,7 @@ namespace nil {
                     static constexpr value_type from_serialized(serialized_type val) {
                         value_type deserialized = base_impl_type::from_serialized(val);
                         if constexpr (is_signed) {
-                            if (crypto3::multiprecision::bit_test(deserialized, bit_length()-1)) {
+                            if (crypto3::multiprecision::bit_test(deserialized, bit_length() - 1)) {
                                 value_type mask = value_type(-1) << bit_length();
                                 return deserialized | mask;
                             } else {
@@ -153,10 +147,9 @@ namespace nil {
                     template<typename TIter>
                     void read_no_status(TIter &iter) {
                         serialized_type serializedValue =
-                            crypto3::marshalling::processing::read_data<
-                                serialized_type,
-                                typename base_impl_type::endian_type
-                            >(iter, _bit_length);
+                            crypto3::marshalling::processing::read_data<serialized_type,
+                                                                        typename base_impl_type::endian_type>(
+                                iter, _bit_length);
                         base_impl_type::value() = from_serialized(serializedValue);
                     }
 
@@ -172,16 +165,14 @@ namespace nil {
 
                     template<typename TIter>
                     void write_no_status(TIter &iter) const {
-                        crypto3::marshalling::processing::write_data<
-                            _bit_length,
-                            typename base_impl_type::endian_type
-                        >(to_serialized(base_impl_type::value()), iter);
+                        crypto3::marshalling::processing::write_data<_bit_length, typename base_impl_type::endian_type>(
+                            to_serialized(base_impl_type::value()), iter);
                     }
                 };
 
             }    // namespace adapter
-        }    // namespace types
-    }    // namespace marshalling
+        }        // namespace types
+    }            // namespace marshalling
 }    // namespace nil
 
 #endif    // CRYPTO3_MARSHALLING_FIXED_BIT_LENGTH_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/types/bitfield.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/bitfield.hpp
@@ -181,6 +181,12 @@ namespace nil {
                         return base_impl_type::max_length();
                     }
 
+                    /// @brief Get bit length required to serialise the current field value.
+                    /// @return Number of bits it will take to serialise the field value.
+                    constexpr std::size_t bit_length() {
+                        return base_impl_type::bit_length();
+                    }
+
                     /// @brief Read field value from input data sequence
                     /// @param[in, out] iter Iterator to read the data.
                     /// @param[in] size Number of bytes available for reading.

--- a/include/nil/crypto3/marshalling/multiprecision/types/bitfield.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/bitfield.hpp
@@ -1,0 +1,390 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017-2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2020-2021 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_BITFIELD_HPP
+#define CRYPTO3_MARSHALLING_BITFIELD_HPP
+
+#include <nil/marshalling/options.hpp>
+#include <nil/marshalling/status_type.hpp>
+#include <nil/marshalling/types/detail/adapt_basic_field.hpp>
+#include <nil/marshalling/types/tag.hpp>
+
+#include <nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp>
+#include <nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp>
+
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace types {
+
+                /// @brief bitfield field.
+                /// @details Sometimes one or several bytes can be logically split into two
+                ///     or more independent values, which are packed together. It could be used to save some
+                ///     space (like core bitfield does) or to implement shifting logic with no extra effort and
+                ///     custom bitwise functions. For example, to split single mutliprecision integer into two of
+                ///     sizes 600 and 424, we could do the following:
+                ///     @code
+                ///         using Integral600Bits = nil::crypto3::marshalling::types::integral<
+                ///             nil::marshalling::field_type<nil::marshalling::option::big_endian>,
+                ///             nil::crypto3::multiprecision::uint1024_t,  // Or any other type 600 bits at least
+                ///             nil::marshalling::option::fixed_bit_length<600>
+                ///         >;
+                ///         using Integral424Bits = nil::crypto3::marshalling::types::integral<
+                ///             nil::marshalling::field_type<nil::marshalling::option::big_endian>,
+                ///             nil::crypto3::multiprecision::uint1024_t,  // Or any other type 600 bits at least
+                ///             nil::marshalling::option::fixed_bit_length<600>
+                ///         >;
+                ///
+                ///         using MyFieldBase = nil::marshalling::field_type<nil::marshalling::option::big_endian>;
+                ///         using MyField =
+                ///             nil::marshalling::types::bitfield<
+                ///                 MyFieldBase,
+                ///                 std::tuple<
+                ///                     Integral600Bits,
+                ///                     Integral424Bits
+                ///                 >
+                ///             >;
+                ///     @endcode
+                ///     Note, that bitfield members fields specify their length in bits using
+                ///     nil::marshalling::option::fixed_bit_length option.
+                ///     Also note, that all bitfield member's lengths in bits combined create
+                ///     a round number of bytes, i.e all the bits must sum up to 8, 16, 24, 32, ...
+                ///     bits.
+                ///
+                ///     Refer to @ref sec_field_tutorial_bitfield for tutorial and usage examples.
+                /// @tparam TFieldBase Base class for this field, expected to be a variant of
+                ///     nil::marshalling::field_type.
+                /// @tparam TMembers All member fields bundled together in
+                ///     <a href="http://en.cppreference.com/w/cpp/utility/tuple">std::tuple</a>.
+                /// @tparam ***MAY BE WRONG, NEEDS VALIDATION*** TOptions Zero or more options that modify/refine
+                ///     default behaviour of the field.@n
+                ///     Supported options are:
+                ///     @li @ref nil::marshalling::option::contents_validator - All field members may specify
+                ///         their independent validators. The bitfield field considered to
+                ///         be valid if all the field members are valid. This option though,
+                ///         provides an ability to add extra validation logic that can
+                ///         observe value of more than one bitfield member. For example,
+                ///         protocol specifies that if one specific member has value X, than
+                ///         other member is NOT allowed to have value Y.
+                ///     @li @ref nil::marshalling::option::contents_refresher - The default refreshing
+                ///         behaviour is to call the @b refresh() member function of every
+                ///         member field. This option provides an ability to set a custom
+                ///         "refreshing" logic.
+                ///     @li @ref nil::marshalling::option::has_custom_read
+                ///     @li @ref nil::marshalling::option::has_custom_refresh
+                ///     @li @ref nil::marshalling::option::empty_serialization
+                ///     @li @ref nil::marshalling::option::version_storage
+                /// @pre TMember is a variant of std::tuple, that contains other fields.
+                /// @pre Every field member specifies its length in bits using
+                ///     nil::marshalling::option::fixed_bit_length option.
+                /// @extends nil::marshalling::field_type
+                /// @headerfile nil/crypto3/marshalling/multiprecision/types/bitfield.hpp
+                /// @see @ref MARSHALLING_FIELD_MEMBERS_ACCESS()
+                /// @see @ref MARSHALLING_FIELD_MEMBERS_ACCESS_NOTEMPLATE()
+                template<typename TFieldBase, typename TMembers, typename... TOptions>
+                class bitfield
+                    : private nil::marshalling::types::detail::adapt_basic_field_type<
+                        detail::basic_bitfield<TFieldBase, TMembers>,
+                        TOptions...
+                    > {
+
+                    using base_impl_type =
+                        nil::marshalling::types::detail::adapt_basic_field_type<
+                            detail::basic_bitfield<TFieldBase, TMembers>,
+                            TOptions...
+                        >;
+
+                public:
+                    /// @brief endian_type used for serialization.
+                    using endian_type = typename base_impl_type::endian_type;
+
+                    /// @brief Version type
+                    using version_type = typename base_impl_type::version_type;
+
+                    /// @brief All the options provided to this class bundled into struct.
+                    using parsed_options_type = nil::marshalling::types::detail::options_parser<TOptions...>;
+
+                    /// @brief Tag indicating type of the field
+                    using tag = nil::marshalling::types::tag::bitfield;
+
+                    /// @brief Value type.
+                    /// @details Same as TMemebers template argument, i.e. it is std::tuple
+                    ///     of all the member fields.
+                    using value_type = typename base_impl_type::value_type;
+
+                    /// @brief Default constructor
+                    /// @details All field members are initialised using their default constructors.
+                    bitfield() = default;
+
+                    /// @brief Constructor
+                    /// @param[in] val Value of the field to initialise it with.
+                    explicit bitfield(const value_type &val) : base_impl_type(val) {
+                    }
+
+                    /// @brief Constructor
+                    /// @param[in] val Value of the field to initialise it with.
+                    explicit bitfield(value_type &&val) : base_impl_type(std::move(val)) {
+                    }
+
+                    /// @brief Retrieve number of bits specified member field consumes.
+                    /// @tparam TIdx Index of the member field.
+                    /// @return Number of bits, specified with nil::marshalling::option::fixed_bit_length option
+                    ///     used with the requested member.
+                    template<std::size_t TIdx>
+                    static constexpr std::size_t member_bit_length() {
+                        return base_impl_type::template member_bit_length<TIdx>();
+                    }
+
+                    /// @brief Get access to the stored tuple of fields.
+                    /// @return Const reference to the underlying stored value.
+                    const value_type &value() const {
+                        return base_impl_type::value();
+                    }
+
+                    /// @brief Get access to the stored tuple of fields.
+                    /// @return Reference to the underlying stored value.
+                    value_type &value() {
+                        return base_impl_type::value();
+                    }
+
+                    /// @brief Get length required to serialise the current field value.
+                    /// @return Number of bytes it will take to serialise the field value.
+                    constexpr std::size_t length() const {
+                        return base_impl_type::length();
+                    }
+
+                    /// @brief Get minimal length that is required to serialise field of this type.
+                    /// @return Minimal number of bytes required serialise the field value.
+                    static constexpr std::size_t min_length() {
+                        return base_impl_type::min_length();
+                    }
+
+                    /// @brief Get maximal length that is required to serialise field of this type.
+                    /// @return Maximal number of bytes required serialise the field value.
+                    static constexpr std::size_t max_length() {
+                        return base_impl_type::max_length();
+                    }
+
+                    /// @brief Read field value from input data sequence
+                    /// @param[in, out] iter Iterator to read the data.
+                    /// @param[in] size Number of bytes available for reading.
+                    /// @return Status of read operation.
+                    /// @post Iterator is advanced.
+                    template<typename TIter>
+                    nil::marshalling::status_type read(TIter &iter, std::size_t size) {
+                        std::cout << size << std::endl;
+                        return base_impl_type::read(iter, size);
+                    }
+
+                    /// @brief Read field value from input data sequence without error check and status report.
+                    /// @details Similar to @ref read(), but doesn't perform any correctness
+                    ///     checks and doesn't report any failures.
+                    /// @param[in, out] iter Iterator to read the data.
+                    /// @post Iterator is advanced.
+                    template<typename TIter>
+                    void read_no_status(TIter &iter) {
+                        base_impl_type::read_no_status(iter);
+                    }
+
+                    /// @brief Write current field value to output data sequence
+                    /// @param[in, out] iter Iterator to write the data.
+                    /// @param[in] size Maximal number of bytes that can be written.
+                    /// @return Status of write operation.
+                    /// @post Iterator is advanced.
+                    template<typename TIter>
+                    nil::marshalling::status_type write(TIter &iter, std::size_t size) const {
+                        return base_impl_type::write(iter, size);
+                    }
+
+                    /// @brief Write current field value to output data sequence  without error check and status report.
+                    /// @details Similar to @ref write(), but doesn't perform any correctness
+                    ///     checks and doesn't report any failures.
+                    /// @param[in, out] iter Iterator to write the data.
+                    /// @post Iterator is advanced.
+                    template<typename TIter>
+                    void write_no_status(TIter &iter) const {
+                        base_impl_type::write_no_status(iter);
+                    }
+
+                    /// @brief Check validity of the field value.
+                    bool valid() const {
+                        return base_impl_type::valid();
+                    }
+
+                    /// @brief Refresh the field's contents
+                    /// @details Calls refresh() member function on every member field, will
+                    ///     return @b true if any of the calls returns @b true.
+                    bool refresh() {
+                        return base_impl_type::refresh();
+                    }
+
+                    /// @brief Compile time check if this class is version dependent
+                    static constexpr bool is_version_dependent() {
+                        return parsed_options_type::has_custom_version_update || base_impl_type::is_version_dependent();
+                    }
+
+                    /// @brief Get version of the field.
+                    /// @details Exists only if @ref nil::marshalling::option::version_storage option has been provided.
+                    version_type get_version() const {
+                        return base_impl_type::get_version();
+                    }
+
+                    /// @brief Default implementation of version update.
+                    /// @return @b true in case the field contents have changed, @b false otherwise
+                    bool set_version(version_type version) {
+                        return base_impl_type::set_version(version);
+                    }
+
+                protected:
+                    using base_impl_type::read_data;
+                    using base_impl_type::write_data;
+
+                private:
+                    static_assert(
+                        !parsed_options_type::has_ser_offset,
+                        "nil::marshalling::option::num_value_ser_offset option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_fixed_length_limit,
+                                "nil::marshalling::option::fixed_length option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_fixed_bit_length_limit,
+                                "nil::marshalling::option::fixed_bit_length option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_var_length_limits,
+                                "nil::marshalling::option::var_length option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_sequence_elem_length_forcing,
+                                "nil::marshalling::option::SequenceElemLengthForcingEnabled option is not applicable to "
+                                "bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_size_forcing,
+                        "nil::marshalling::option::sequence_size_forcing_enabled option is not applicable to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_length_forcing,
+                        "nil::marshalling::option::SequenceLengthorcingEnabled option is not applicable to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_fixed_size,
+                        "nil::marshalling::option::sequence_fixed_size option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_sequence_fixed_size_use_fixed_size_storage,
+                                "nil::marshalling::option::SequenceFixedSizeUseFixedSizeStorage option is not applicable "
+                                "to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_size_field_prefix,
+                        "nil::marshalling::option::sequence_size_field_prefix option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_sequence_ser_length_field_prefix,
+                                "nil::marshalling::option::sequence_ser_length_field_prefix option is not applicable to "
+                                "bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_elem_ser_length_field_prefix,
+                        "nil::marshalling::option::sequence_elem_ser_length_field_prefix option is not applicable to "
+                        "bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_elem_fixed_ser_length_field_prefix,
+                        "nil::marshalling::option::SequenceElemSerLengthFixedFieldPrefix option is not applicable to "
+                        "bitfield field");
+                    static_assert(!parsed_options_type::has_sequence_trailing_field_suffix,
+                                "nil::marshalling::option::sequence_trailing_field_suffix option is not applicable to "
+                                "bitfield field");
+                    static_assert(!parsed_options_type::has_sequence_termination_field_suffix,
+                                "nil::marshalling::option::sequence_termination_field_suffix option is not applicable to "
+                                "bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_fixed_size_storage,
+                        "nil::marshalling::option::fixed_size_storage option is not applicable to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_custom_storage_type,
+                        "nil::marshalling::option::custom_storage_type option is not applicable to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_scaling_ratio,
+                        "nil::marshalling::option::scaling_ratio_type option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_units,
+                                "nil::marshalling::option::Units option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_orig_data_view,
+                                "nil::marshalling::option::orig_data_view option is not applicable to bitfield field");
+                    static_assert(!parsed_options_type::has_multi_range_validation,
+                                "nil::marshalling::option::valid_num_value_range (or similar) option is not applicable "
+                                "to bitfield field");
+                    static_assert(!parsed_options_type::has_versions_range,
+                                "nil::marshalling::option::exists_between_versions (or similar) option is not applicable "
+                                "to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_invalid_by_default,
+                        "nil::marshalling::option::invalid_by_default option is not applicable to bitfield field");
+                };
+
+                /// @brief Equality comparison operator.
+                /// @param[in] field1 First field.
+                /// @param[in] field2 Second field.
+                /// @return true in case fields are equal, false otherwise.
+                /// @related bitfield
+                template<typename TFieldBase, typename TMembers, typename... TOptions>
+                bool operator==(const bitfield<TFieldBase, TMembers, TOptions...> &field1,
+                                const bitfield<TFieldBase, TMembers, TOptions...> &field2) {
+                    return field1.value() == field2.value();
+                }
+
+                /// @brief Non-equality comparison operator.
+                /// @param[in] field1 First field.
+                /// @param[in] field2 Second field.
+                /// @return true in case fields are NOT equal, false otherwise.
+                /// @related bitfield
+                template<typename TFieldBase, typename TMembers, typename... TOptions>
+                bool operator!=(const bitfield<TFieldBase, TMembers, TOptions...> &field1,
+                                const bitfield<TFieldBase, TMembers, TOptions...> &field2) {
+                    return field1.value() != field2.value();
+                }
+
+                /// @brief Equivalence comparison operator.
+                /// @param[in] field1 First field.
+                /// @param[in] field2 Second field.
+                /// @return true in case value of the first field is lower than than the value of the second.
+                /// @related bitfield
+                template<typename TFieldBase, typename TMembers, typename... TOptions>
+                bool operator<(const bitfield<TFieldBase, TMembers, TOptions...> &field1,
+                            const bitfield<TFieldBase, TMembers, TOptions...> &field2) {
+                    return field1.value() < field2.value();
+                }
+
+                /// @brief Upcast type of the field definition to its parent nil::marshalling::types::bitfield type
+                ///     in order to have access to its internal types.
+                /// @related nil::marshalling::types::bitfield
+                template<typename TFieldBase, typename TMembers, typename... TOptions>
+                inline bitfield<TFieldBase, TMembers, TOptions...> &
+                    to_field_base(bitfield<TFieldBase, TMembers, TOptions...> &field) {
+                    return field;
+                }
+
+                /// @brief Upcast type of the field definition to its parent nil::marshalling::types::bitfield type
+                ///     in order to have access to its internal types.
+                /// @related nil::marshalling::types::bitfield
+                template<typename TFieldBase, typename TMembers, typename... TOptions>
+                inline const bitfield<TFieldBase, TMembers, TOptions...> &
+                    to_field_base(const bitfield<TFieldBase, TMembers, TOptions...> &field) {
+                    return field;
+                }
+
+            }    // namespace types
+        }    // namespace marshalling
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_MARSHALLING_BITFIELD_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/types/bitfield.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/bitfield.hpp
@@ -34,7 +34,6 @@
 #include <nil/crypto3/marshalling/multiprecision/types/adapter/fixed_bit_length.hpp>
 #include <nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp>
 
-
 namespace nil {
     namespace crypto3 {
         namespace marshalling {
@@ -105,17 +104,11 @@ namespace nil {
                 /// @see @ref MARSHALLING_FIELD_MEMBERS_ACCESS()
                 /// @see @ref MARSHALLING_FIELD_MEMBERS_ACCESS_NOTEMPLATE()
                 template<typename TFieldBase, typename TMembers, typename... TOptions>
-                class bitfield
-                    : private nil::marshalling::types::detail::adapt_basic_field_type<
-                        detail::basic_bitfield<TFieldBase, TMembers>,
-                        TOptions...
-                    > {
+                class bitfield : private nil::marshalling::types::detail::
+                                     adapt_basic_field_type<detail::basic_bitfield<TFieldBase, TMembers>, TOptions...> {
 
-                    using base_impl_type =
-                        nil::marshalling::types::detail::adapt_basic_field_type<
-                            detail::basic_bitfield<TFieldBase, TMembers>,
-                            TOptions...
-                        >;
+                    using base_impl_type = nil::marshalling::types::detail::
+                        adapt_basic_field_type<detail::basic_bitfield<TFieldBase, TMembers>, TOptions...>;
 
                 public:
                     /// @brief endian_type used for serialization.
@@ -267,32 +260,36 @@ namespace nil {
                         !parsed_options_type::has_ser_offset,
                         "nil::marshalling::option::num_value_ser_offset option is not applicable to bitfield field");
                     static_assert(!parsed_options_type::has_fixed_length_limit,
-                                "nil::marshalling::option::fixed_length option is not applicable to bitfield field");
-                    static_assert(!parsed_options_type::has_fixed_bit_length_limit,
-                                "nil::marshalling::option::fixed_bit_length option is not applicable to bitfield field");
+                                  "nil::marshalling::option::fixed_length option is not applicable to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_fixed_bit_length_limit,
+                        "nil::marshalling::option::fixed_bit_length option is not applicable to bitfield field");
                     static_assert(!parsed_options_type::has_var_length_limits,
-                                "nil::marshalling::option::var_length option is not applicable to bitfield field");
-                    static_assert(!parsed_options_type::has_sequence_elem_length_forcing,
-                                "nil::marshalling::option::SequenceElemLengthForcingEnabled option is not applicable to "
-                                "bitfield field");
+                                  "nil::marshalling::option::var_length option is not applicable to bitfield field");
                     static_assert(
-                        !parsed_options_type::has_sequence_size_forcing,
-                        "nil::marshalling::option::sequence_size_forcing_enabled option is not applicable to bitfield field");
-                    static_assert(
-                        !parsed_options_type::has_sequence_length_forcing,
-                        "nil::marshalling::option::SequenceLengthorcingEnabled option is not applicable to bitfield field");
+                        !parsed_options_type::has_sequence_elem_length_forcing,
+                        "nil::marshalling::option::SequenceElemLengthForcingEnabled option is not applicable to "
+                        "bitfield field");
+                    static_assert(!parsed_options_type::has_sequence_size_forcing,
+                                  "nil::marshalling::option::sequence_size_forcing_enabled option is not applicable to "
+                                  "bitfield field");
+                    static_assert(!parsed_options_type::has_sequence_length_forcing,
+                                  "nil::marshalling::option::SequenceLengthorcingEnabled option is not applicable to "
+                                  "bitfield field");
                     static_assert(
                         !parsed_options_type::has_sequence_fixed_size,
                         "nil::marshalling::option::sequence_fixed_size option is not applicable to bitfield field");
-                    static_assert(!parsed_options_type::has_sequence_fixed_size_use_fixed_size_storage,
-                                "nil::marshalling::option::SequenceFixedSizeUseFixedSizeStorage option is not applicable "
-                                "to bitfield field");
                     static_assert(
-                        !parsed_options_type::has_sequence_size_field_prefix,
-                        "nil::marshalling::option::sequence_size_field_prefix option is not applicable to bitfield field");
-                    static_assert(!parsed_options_type::has_sequence_ser_length_field_prefix,
-                                "nil::marshalling::option::sequence_ser_length_field_prefix option is not applicable to "
-                                "bitfield field");
+                        !parsed_options_type::has_sequence_fixed_size_use_fixed_size_storage,
+                        "nil::marshalling::option::SequenceFixedSizeUseFixedSizeStorage option is not applicable "
+                        "to bitfield field");
+                    static_assert(!parsed_options_type::has_sequence_size_field_prefix,
+                                  "nil::marshalling::option::sequence_size_field_prefix option is not applicable to "
+                                  "bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_ser_length_field_prefix,
+                        "nil::marshalling::option::sequence_ser_length_field_prefix option is not applicable to "
+                        "bitfield field");
                     static_assert(
                         !parsed_options_type::has_sequence_elem_ser_length_field_prefix,
                         "nil::marshalling::option::sequence_elem_ser_length_field_prefix option is not applicable to "
@@ -301,12 +298,14 @@ namespace nil {
                         !parsed_options_type::has_sequence_elem_fixed_ser_length_field_prefix,
                         "nil::marshalling::option::SequenceElemSerLengthFixedFieldPrefix option is not applicable to "
                         "bitfield field");
-                    static_assert(!parsed_options_type::has_sequence_trailing_field_suffix,
-                                "nil::marshalling::option::sequence_trailing_field_suffix option is not applicable to "
-                                "bitfield field");
-                    static_assert(!parsed_options_type::has_sequence_termination_field_suffix,
-                                "nil::marshalling::option::sequence_termination_field_suffix option is not applicable to "
-                                "bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_trailing_field_suffix,
+                        "nil::marshalling::option::sequence_trailing_field_suffix option is not applicable to "
+                        "bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_sequence_termination_field_suffix,
+                        "nil::marshalling::option::sequence_termination_field_suffix option is not applicable to "
+                        "bitfield field");
                     static_assert(
                         !parsed_options_type::has_fixed_size_storage,
                         "nil::marshalling::option::fixed_size_storage option is not applicable to bitfield field");
@@ -317,15 +316,18 @@ namespace nil {
                         !parsed_options_type::has_scaling_ratio,
                         "nil::marshalling::option::scaling_ratio_type option is not applicable to bitfield field");
                     static_assert(!parsed_options_type::has_units,
-                                "nil::marshalling::option::Units option is not applicable to bitfield field");
-                    static_assert(!parsed_options_type::has_orig_data_view,
-                                "nil::marshalling::option::orig_data_view option is not applicable to bitfield field");
-                    static_assert(!parsed_options_type::has_multi_range_validation,
-                                "nil::marshalling::option::valid_num_value_range (or similar) option is not applicable "
-                                "to bitfield field");
-                    static_assert(!parsed_options_type::has_versions_range,
-                                "nil::marshalling::option::exists_between_versions (or similar) option is not applicable "
-                                "to bitfield field");
+                                  "nil::marshalling::option::Units option is not applicable to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_orig_data_view,
+                        "nil::marshalling::option::orig_data_view option is not applicable to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_multi_range_validation,
+                        "nil::marshalling::option::valid_num_value_range (or similar) option is not applicable "
+                        "to bitfield field");
+                    static_assert(
+                        !parsed_options_type::has_versions_range,
+                        "nil::marshalling::option::exists_between_versions (or similar) option is not applicable "
+                        "to bitfield field");
                     static_assert(
                         !parsed_options_type::has_invalid_by_default,
                         "nil::marshalling::option::invalid_by_default option is not applicable to bitfield field");
@@ -360,7 +362,7 @@ namespace nil {
                 /// @related bitfield
                 template<typename TFieldBase, typename TMembers, typename... TOptions>
                 bool operator<(const bitfield<TFieldBase, TMembers, TOptions...> &field1,
-                            const bitfield<TFieldBase, TMembers, TOptions...> &field2) {
+                               const bitfield<TFieldBase, TMembers, TOptions...> &field2) {
                     return field1.value() < field2.value();
                 }
 
@@ -383,8 +385,8 @@ namespace nil {
                 }
 
             }    // namespace types
-        }    // namespace marshalling
-    }    // namespace crypto3
+        }        // namespace marshalling
+    }            // namespace crypto3
 }    // namespace nil
 
 #endif    // CRYPTO3_MARSHALLING_BITFIELD_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp
@@ -33,7 +33,6 @@
 #include <nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp>
 #include <nil/crypto3/marshalling/multiprecision/types/integral.hpp>
 
-
 namespace nil {
     namespace crypto3 {
         namespace marshalling {
@@ -45,14 +44,15 @@ namespace nil {
                         using base_impl_type = TFieldBase;
 
                         static_assert(nil::detail::is_tuple<TMembers>::value,
-                                    "TMembers is expected to be a tuple of BitfieldMember<...>");
+                                      "TMembers is expected to be a tuple of BitfieldMember<...>");
 
                         static_assert(1U < std::tuple_size<TMembers>::value,
-                                    "Number of members is expected to be at least 2.");
+                                      "Number of members is expected to be at least 2.");
 
-                        static constexpr std::size_t total_bits = nil::marshalling::types::detail::calc_bit_length<TMembers>();
+                        static constexpr std::size_t total_bits =
+                            nil::marshalling::types::detail::calc_bit_length<TMembers>();
                         static_assert((total_bits % std::numeric_limits<std::uint8_t>::digits) == 0,
-                                    "Wrong number of total bits, it should be devidable by 8");
+                                      "Wrong number of total bits, it should be devidable by 8");
 
                         static const std::size_t total_bytes = total_bits / std::numeric_limits<std::uint8_t>::digits;
                         static_assert(0U < total_bytes, "Serialised length is expected to be greater than 0");
@@ -98,26 +98,18 @@ namespace nil {
                                 return nil::marshalling::status_type::not_enough_data;
                             }
 
-                            serialized_type serValue = processing::read_data<
-                                total_bits,
-                                serialized_type,
-                                endian_type
-                            >(iter);
+                            serialized_type serValue =
+                                processing::read_data<total_bits, serialized_type, endian_type>(iter);
                             nil::marshalling::status_type es = nil::marshalling::status_type::success;
                             nil::marshalling::processing::tuple_for_each_with_template_param_idx(
-                                members_,
-                                read_helper(serValue, es)
-                            );
+                                members_, read_helper(serValue, es));
                             return es;
                         }
 
                         template<typename TIter>
                         void read_no_status(TIter &iter) {
-                            serialized_type serValue = processing::read_data<
-                                total_bits,
-                                serialized_type,
-                                endian_type
-                            >(iter);
+                            serialized_type serValue =
+                                processing::read_data<total_bits, serialized_type, endian_type>(iter);
                             nil::marshalling::processing::tuple_for_each_with_template_param_idx(
                                 members_, read_no_status_helper(serValue));
                         }
@@ -133,10 +125,7 @@ namespace nil {
                             nil::marshalling::processing::tuple_for_each_with_template_param_idx(
                                 members_, write_helper(serValue, es));
                             if (es == nil::marshalling::status_type::success) {
-                                processing::write_data<
-                                    total_bits,
-                                    endian_type
-                                >(serValue, iter);
+                                processing::write_data<total_bits, endian_type>(serValue, iter);
                             }
                             return es;
                         }
@@ -166,11 +155,13 @@ namespace nil {
                         }
 
                         static constexpr bool is_version_dependent() {
-                            return nil::marshalling::types::detail::common_funcs::are_members_version_dependent<value_type>();
+                            return nil::marshalling::types::detail::common_funcs::are_members_version_dependent<
+                                value_type>();
                         }
 
                         bool set_version(version_type version) {
-                            return nil::marshalling::types::detail::common_funcs::set_version_for_members(value(), version);
+                            return nil::marshalling::types::detail::common_funcs::set_version_for_members(value(),
+                                                                                                          version);
                         }
 
                     private:
@@ -186,14 +177,18 @@ namespace nil {
                                 }
 
                                 using field_type = typename std::decay<TFieldParam>::type;
-                                static const auto Pos = nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
+                                static const auto Pos =
+                                    nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
                                 static const auto Mask =
-                                    (static_cast<serialized_type>(1U) << nil::marshalling::types::detail::bitfield_member_length_retriever<field_type>::value)- 1;
+                                    (static_cast<serialized_type>(1U)
+                                     << nil::marshalling::types::detail::bitfield_member_length_retriever<
+                                            field_type>::value) -
+                                    1;
 
                                 auto fieldSerValue = static_cast<serialized_type>((value_ >> Pos) & Mask);
 
                                 static_assert(field_type::min_length() == field_type::max_length(),
-                                            "basic_bitfield doesn't support members with variable length");
+                                              "basic_bitfield doesn't support members with variable length");
 
                                 static const std::size_t max_length = field_type::max_length();
                                 std::uint8_t buf[max_length];
@@ -204,7 +199,8 @@ namespace nil {
 
                                 auto readIter = std::cbegin(buf);
                                 es_ = field.read(readIter, field_type::bit_length());
-                                using unsigned_seriealized_type = typename crypto3::marshalling::processing::size_to_type<128>::type;
+                                using unsigned_seriealized_type =
+                                    typename crypto3::marshalling::processing::size_to_type<128>::type;
                             }
 
                         private:
@@ -221,14 +217,15 @@ namespace nil {
                             void operator()(TFieldParam &&field) {
                                 using field_type = typename std::decay<decltype(field)>::type;
                                 using FieldOptions = typename field_type::parsed_options_type;
-                                static const auto Pos = nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
-                                static const auto Mask
-                                    = (static_cast<serialized_type>(1) << FieldOptions::fixed_bit_length) - 1;
+                                static const auto Pos =
+                                    nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
+                                static const auto Mask =
+                                    (static_cast<serialized_type>(1) << FieldOptions::fixed_bit_length) - 1;
 
                                 auto fieldSerValue = static_cast<serialized_type>((value_ >> Pos) & Mask);
 
                                 static_assert(field_type::min_length() == field_type::max_length(),
-                                            "basic_bitfield doesn't support members with variable length");
+                                              "basic_bitfield doesn't support members with variable length");
 
                                 std::uint8_t buf[field_type::max_length()];
                                 auto writeIter = std::begin(buf);
@@ -245,7 +242,8 @@ namespace nil {
 
                         class write_helper {
                         public:
-                            write_helper(serialized_type &val, nil::marshalling::status_type &es) : value_(val), es_(es) {
+                            write_helper(serialized_type &val, nil::marshalling::status_type &es) :
+                                value_(val), es_(es) {
                             }
 
                             template<std::size_t TIdx, typename TFieldParam>
@@ -257,13 +255,14 @@ namespace nil {
                                 using field_type = typename std::decay<decltype(field)>::type;
 
                                 static_assert(field_type::min_length() == field_type::max_length(),
-                                            "basic_bitfield supports fixed length members only.");
+                                              "basic_bitfield supports fixed length members only.");
 
                                 std::uint8_t buf[field_type::max_length()];
                                 auto writeIter = std::begin(buf);
 
                                 nil::marshalling::status_type status;
-                                es_ = field.write(writeIter, field_type::bit_length()); // TODO: len as template param?
+                                es_ =
+                                    field.write(writeIter, field_type::bit_length());    // TODO: len as template param?
 
                                 if (es_ != nil::marshalling::status_type::success) {
                                     return;
@@ -271,16 +270,17 @@ namespace nil {
 
                                 auto readIter = std::cbegin(buf);
                                 serialized_type fieldSerValue =
-                                    processing::read_data<
-                                        field_type::bit_length(),
-                                        serialized_type,
-                                        typename field_type::endian_type
-                                    >(readIter);
+                                    processing::read_data<field_type::bit_length(),
+                                                          serialized_type,
+                                                          typename field_type::endian_type>(readIter);
 
-
-                                static const auto Pos = nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
+                                static const auto Pos =
+                                    nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
                                 static const auto Mask =
-                                    (static_cast<serialized_type>(1U) << nil::marshalling::types::detail::bitfield_member_length_retriever<field_type>::value) - 1;
+                                    (static_cast<serialized_type>(1U)
+                                     << nil::marshalling::types::detail::bitfield_member_length_retriever<
+                                            field_type>::value) -
+                                    1;
 
                                 static const auto ClearMask = ~(Mask << Pos);
 
@@ -306,7 +306,7 @@ namespace nil {
                                 using field_type = typename std::decay<decltype(field)>::type;
 
                                 static_assert(field_type::min_length() == field_type::max_length(),
-                                            "basic_bitfield supports fixed length members only.");
+                                              "basic_bitfield supports fixed length members only.");
 
                                 static const std::size_t max_length = field_type::max_length();
                                 std::uint8_t buf[max_length];
@@ -314,16 +314,15 @@ namespace nil {
                                 field.write_no_status(writeIter);
 
                                 auto readIter = std::cbegin(buf);
-                                auto fieldSerValue = processing::read_data<
-                                        field_type::bit_length(),
-                                        serialized_type,
-                                        typename field_type::endian_type
-                                    >(readIter);
+                                auto fieldSerValue = processing::read_data<field_type::bit_length(),
+                                                                           serialized_type,
+                                                                           typename field_type::endian_type>(readIter);
 
                                 using FieldOptions = typename field_type::parsed_options_type;
-                                static const auto Pos = nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
-                                static const auto Mask
-                                    = (static_cast<serialized_type>(1) << FieldOptions::fixed_bit_length) - 1;
+                                static const auto Pos =
+                                    nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
+                                static const auto Mask =
+                                    (static_cast<serialized_type>(1) << FieldOptions::fixed_bit_length) - 1;
 
                                 static const auto ClearMask = ~(Mask << Pos);
 
@@ -355,9 +354,9 @@ namespace nil {
                     };
 
                 }    // namespace detail
-            }    // namespace types
-        }    // namespace marshalling
-    }    // namespace crypto3
+            }        // namespace types
+        }            // namespace marshalling
+    }                // namespace crypto3
 }    // namespace nil
 
 #endif    // CRYPTO3_MARSHALLING_BASIC_BITFIELD_DEFINITION_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp
@@ -1,0 +1,363 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017-2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2020-2021 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_MARSHALLING_BASIC_BITFIELD_DEFINITION_HPP
+#define CRYPTO3_MARSHALLING_BASIC_BITFIELD_DEFINITION_HPP
+
+#include <boost/type_traits/is_integral.hpp>
+#include <nil/marshalling/processing/tuple.hpp>
+#include <nil/marshalling/types/bitfield/type_traits.hpp>
+
+#include <nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp>
+#include <nil/crypto3/marshalling/multiprecision/types/integral.hpp>
+
+
+namespace nil {
+    namespace crypto3 {
+        namespace marshalling {
+            namespace types {
+                namespace detail {
+
+                    template<typename TFieldBase, typename TMembers>
+                    class basic_bitfield : public TFieldBase {
+                        using base_impl_type = TFieldBase;
+
+                        static_assert(nil::detail::is_tuple<TMembers>::value,
+                                    "TMembers is expected to be a tuple of BitfieldMember<...>");
+
+                        static_assert(1U < std::tuple_size<TMembers>::value,
+                                    "Number of members is expected to be at least 2.");
+
+                        static constexpr std::size_t total_bits = nil::marshalling::types::detail::calc_bit_length<TMembers>();
+                        static_assert((total_bits % std::numeric_limits<std::uint8_t>::digits) == 0,
+                                    "Wrong number of total bits, it should be devidable by 8");
+
+                        static const std::size_t total_bytes = total_bits / std::numeric_limits<std::uint8_t>::digits;
+                        static_assert(0U < total_bytes, "Serialised length is expected to be greater than 0");
+
+                        using serialized_type = typename processing::size_to_type<total_bits>::type;
+
+                    public:
+                        using endian_type = typename base_impl_type::endian_type;
+                        using version_type = typename base_impl_type::version_type;
+                        using value_type = TMembers;
+
+                        basic_bitfield() = default;
+
+                        explicit basic_bitfield(const value_type &val) : members_(val) {
+                        }
+
+                        explicit basic_bitfield(value_type &&val) : members_(std::move(val)) {
+                        }
+
+                        const value_type &value() const {
+                            return members_;
+                        }
+
+                        value_type &value() {
+                            return members_;
+                        }
+
+                        static constexpr std::size_t length() {
+                            return total_bytes;
+                        }
+
+                        static constexpr std::size_t min_length() {
+                            return length();
+                        }
+
+                        static constexpr std::size_t max_length() {
+                            return length();
+                        }
+
+                        template<typename TIter>
+                        nil::marshalling::status_type read(TIter &iter, std::size_t size) {
+                            if (size < length()) {
+                                return nil::marshalling::status_type::not_enough_data;
+                            }
+
+                            serialized_type serValue = processing::read_data<
+                                total_bits,
+                                serialized_type,
+                                endian_type
+                            >(iter);
+                            nil::marshalling::status_type es = nil::marshalling::status_type::success;
+                            nil::marshalling::processing::tuple_for_each_with_template_param_idx(
+                                members_,
+                                read_helper(serValue, es)
+                            );
+                            return es;
+                        }
+
+                        template<typename TIter>
+                        void read_no_status(TIter &iter) {
+                            serialized_type serValue = processing::read_data<
+                                total_bits,
+                                serialized_type,
+                                endian_type
+                            >(iter);
+                            nil::marshalling::processing::tuple_for_each_with_template_param_idx(
+                                members_, read_no_status_helper(serValue));
+                        }
+
+                        template<typename TIter>
+                        nil::marshalling::status_type write(TIter &iter, std::size_t size) const {
+                            if (size < length()) {
+                                return nil::marshalling::status_type::buffer_overflow;
+                            }
+
+                            serialized_type serValue = 0;
+                            nil::marshalling::status_type es = nil::marshalling::status_type::success;
+                            nil::marshalling::processing::tuple_for_each_with_template_param_idx(
+                                members_, write_helper(serValue, es));
+                            if (es == nil::marshalling::status_type::success) {
+                                processing::write_data<
+                                    total_bits,
+                                    endian_type
+                                >(serValue, iter);
+                            }
+                            return es;
+                        }
+
+                        template<typename TIter>
+                        void write_no_status(TIter &iter) const {
+                            serialized_type serValue = 0;
+                            nil::marshalling::processing::tuple_for_each_with_template_param_idx(
+                                members_, write_no_status_helper(serValue));
+                            processing::write_data<total_bits, endian_type>(serValue, iter);
+                        }
+
+                        constexpr bool valid() const {
+                            return nil::marshalling::processing::tuple_accumulate(members_, true, valid_helper());
+                        }
+
+                        bool refresh() {
+                            return nil::marshalling::processing::tuple_accumulate(members_, false, refresh_helper());
+                        }
+
+                        template<std::size_t TIdx>
+                        static constexpr std::size_t member_bit_length() {
+                            static_assert(TIdx < std::tuple_size<value_type>::value, "Index exceeds number of fields");
+
+                            using field_type = typename std::tuple_element<TIdx, value_type>::type;
+                            return nil::marshalling::types::detail::bitfield_member_length_retriever<field_type>::value;
+                        }
+
+                        static constexpr bool is_version_dependent() {
+                            return nil::marshalling::types::detail::common_funcs::are_members_version_dependent<value_type>();
+                        }
+
+                        bool set_version(version_type version) {
+                            return nil::marshalling::types::detail::common_funcs::set_version_for_members(value(), version);
+                        }
+
+                    private:
+                        class read_helper {
+                        public:
+                            read_helper(serialized_type val, nil::marshalling::status_type &es) : value_(val), es_(es) {
+                            }
+
+                            template<std::size_t TIdx, typename TFieldParam>
+                            void operator()(TFieldParam &&field) {
+                                if (es_ != nil::marshalling::status_type::success) {
+                                    return;
+                                }
+
+                                using field_type = typename std::decay<TFieldParam>::type;
+                                static const auto Pos = nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
+                                static const auto Mask =
+                                    (static_cast<serialized_type>(1U) << nil::marshalling::types::detail::bitfield_member_length_retriever<field_type>::value)- 1;
+
+                                auto fieldSerValue = static_cast<serialized_type>((value_ >> Pos) & Mask);
+
+                                static_assert(field_type::min_length() == field_type::max_length(),
+                                            "basic_bitfield doesn't support members with variable length");
+
+                                static const std::size_t max_length = field_type::max_length();
+                                std::uint8_t buf[max_length];
+                                auto writeIter = std::begin(buf);
+
+                                processing::write_data<field_type::bit_length(), typename field_type::endian_type>(
+                                    fieldSerValue, writeIter);
+
+                                auto readIter = std::cbegin(buf);
+                                es_ = field.read(readIter, field_type::bit_length());
+                                using unsigned_seriealized_type = typename crypto3::marshalling::processing::size_to_type<128>::type;
+                            }
+
+                        private:
+                            serialized_type value_;
+                            nil::marshalling::status_type &es_;
+                        };
+
+                        class read_no_status_helper {
+                        public:
+                            read_no_status_helper(serialized_type val) : value_(val) {
+                            }
+
+                            template<std::size_t TIdx, typename TFieldParam>
+                            void operator()(TFieldParam &&field) {
+                                using field_type = typename std::decay<decltype(field)>::type;
+                                using FieldOptions = typename field_type::parsed_options_type;
+                                static const auto Pos = nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
+                                static const auto Mask
+                                    = (static_cast<serialized_type>(1) << FieldOptions::fixed_bit_length) - 1;
+
+                                auto fieldSerValue = static_cast<serialized_type>((value_ >> Pos) & Mask);
+
+                                static_assert(field_type::min_length() == field_type::max_length(),
+                                            "basic_bitfield doesn't support members with variable length");
+
+                                std::uint8_t buf[field_type::max_length()];
+                                auto writeIter = std::begin(buf);
+                                processing::write_data<field_type::bit_length(), typename field_type::endian_type>(
+                                    fieldSerValue, writeIter);
+
+                                auto readIter = std::cbegin(buf);
+                                field.read_no_status(readIter);
+                            }
+
+                        private:
+                            serialized_type value_;
+                        };
+
+                        class write_helper {
+                        public:
+                            write_helper(serialized_type &val, nil::marshalling::status_type &es) : value_(val), es_(es) {
+                            }
+
+                            template<std::size_t TIdx, typename TFieldParam>
+                            void operator()(TFieldParam &&field) {
+                                if (es_ != nil::marshalling::status_type::success) {
+                                    return;
+                                }
+
+                                using field_type = typename std::decay<decltype(field)>::type;
+
+                                static_assert(field_type::min_length() == field_type::max_length(),
+                                            "basic_bitfield supports fixed length members only.");
+
+                                std::uint8_t buf[field_type::max_length()];
+                                auto writeIter = std::begin(buf);
+
+                                nil::marshalling::status_type status;
+                                es_ = field.write(writeIter, field_type::bit_length()); // TODO: len as template param?
+
+                                if (es_ != nil::marshalling::status_type::success) {
+                                    return;
+                                }
+
+                                auto readIter = std::cbegin(buf);
+                                serialized_type fieldSerValue =
+                                    processing::read_data<
+                                        field_type::bit_length(),
+                                        serialized_type,
+                                        typename field_type::endian_type
+                                    >(readIter);
+
+
+                                static const auto Pos = nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
+                                static const auto Mask =
+                                    (static_cast<serialized_type>(1U) << nil::marshalling::types::detail::bitfield_member_length_retriever<field_type>::value) - 1;
+
+                                static const auto ClearMask = ~(Mask << Pos);
+
+                                auto valueMask = (fieldSerValue & Mask) << Pos;
+
+                                value_ &= ClearMask;
+                                value_ |= valueMask;
+                            }
+
+                        private:
+                            serialized_type &value_;
+                            nil::marshalling::status_type &es_;
+                        };
+
+                        class write_no_status_helper {
+                        public:
+                            write_no_status_helper(serialized_type &val) : value_(val) {
+                            }
+
+                            template<std::size_t TIdx, typename TFieldParam>
+                            void operator()(TFieldParam &&field) {
+
+                                using field_type = typename std::decay<decltype(field)>::type;
+
+                                static_assert(field_type::min_length() == field_type::max_length(),
+                                            "basic_bitfield supports fixed length members only.");
+
+                                static const std::size_t max_length = field_type::max_length();
+                                std::uint8_t buf[max_length];
+                                auto writeIter = std::begin(buf);
+                                field.write_no_status(writeIter);
+
+                                auto readIter = std::cbegin(buf);
+                                auto fieldSerValue = processing::read_data<
+                                        field_type::bit_length(),
+                                        serialized_type,
+                                        typename field_type::endian_type
+                                    >(readIter);
+
+                                using FieldOptions = typename field_type::parsed_options_type;
+                                static const auto Pos = nil::marshalling::types::detail::get_member_shift_pos<TIdx, value_type>();
+                                static const auto Mask
+                                    = (static_cast<serialized_type>(1) << FieldOptions::fixed_bit_length) - 1;
+
+                                static const auto ClearMask = ~(Mask << Pos);
+
+                                auto valueMask = (static_cast<serialized_type>(fieldSerValue) & Mask) << Pos;
+
+                                value_ &= ClearMask;
+                                value_ |= valueMask;
+                            }
+
+                        private:
+                            serialized_type &value_;
+                        };
+
+                        struct valid_helper {
+                            template<typename TFieldParam>
+                            bool operator()(bool soFar, const TFieldParam &field) {
+                                return soFar && field.valid();
+                            }
+                        };
+
+                        struct refresh_helper {
+                            template<typename TFieldParam>
+                            bool operator()(bool soFar, TFieldParam &field) {
+                                return field.refresh() || soFar;
+                            }
+                        };
+
+                        value_type members_;
+                    };
+
+                }    // namespace detail
+            }    // namespace types
+        }    // namespace marshalling
+    }    // namespace crypto3
+}    // namespace nil
+
+#endif    // CRYPTO3_MARSHALLING_BASIC_BITFIELD_DEFINITION_HPP

--- a/include/nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp
@@ -199,8 +199,6 @@ namespace nil {
 
                                 auto readIter = std::cbegin(buf);
                                 es_ = field.read(readIter, field_type::bit_length());
-                                using unsigned_seriealized_type =
-                                    typename crypto3::marshalling::processing::size_to_type<128>::type;
                             }
 
                         private:

--- a/include/nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/detail/bitfield/basic_type.hpp
@@ -92,6 +92,10 @@ namespace nil {
                             return length();
                         }
 
+                        static constexpr std::size_t bit_length() {
+                            return total_bits;
+                        }
+
                         template<typename TIter>
                         nil::marshalling::status_type read(TIter &iter, std::size_t size) {
                             if (size < length()) {

--- a/include/nil/crypto3/marshalling/multiprecision/types/integral.hpp
+++ b/include/nil/crypto3/marshalling/multiprecision/types/integral.hpp
@@ -256,12 +256,6 @@ namespace nil {
                                   "nil::marshalling::option::fixed_length option is not applicable to "
                                   "crypto3::integral type");
 
-                    // because such an adapter uses pure byte reading,
-                    // incompatible with crypto3::multiprecision
-                    static_assert(!parsed_options_type::has_fixed_bit_length_limit,
-                                  "nil::marshalling::option::fixed_bit_length option is not applicable to "
-                                  "crypto3::integral type");
-
                     static_assert(!parsed_options_type::has_scaling_ratio,
                                   "nil::marshalling::option::scaling_ratio option is not applicable to "
                                   "crypto3::integral type");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(TESTS_NAMES
     "integral"
     "integral_fixed_size_container"
     "integral_non_fixed_size_container"
+    "bitfield"
     )
 
 foreach(TEST_NAME ${TESTS_NAMES})

--- a/test/bitfield.cpp
+++ b/test/bitfield.cpp
@@ -41,20 +41,17 @@
 #include <nil/crypto3/marshalling/multiprecision/types/bitfield.hpp>
 #include "utils.h"
 
-
-template <size_t FixedBitLength, size_t BaseTypeBitLength = 1024, bool IsSigned = false, typename Endianness = nil::marshalling::option::big_endian>
-using integral_type =
-    nil::crypto3::marshalling::types::integral<
-        nil::marshalling::field_type<Endianness>,
-        typename nil::crypto3::marshalling::processing::size_to_type<BaseTypeBitLength, IsSigned>::type,
-        nil::marshalling::option::fixed_bit_length<FixedBitLength>
-    >;
+template<size_t FixedBitLength,
+         size_t BaseTypeBitLength = 1024,
+         bool IsSigned = false,
+         typename Endianness = nil::marshalling::option::big_endian>
+using integral_type = nil::crypto3::marshalling::types::integral<
+    nil::marshalling::field_type<Endianness>,
+    typename nil::crypto3::marshalling::processing::size_to_type<BaseTypeBitLength, IsSigned>::type,
+    nil::marshalling::option::fixed_bit_length<FixedBitLength>>;
 
 template<typename TField>
-void test_buffer_equality(
-    const TField &field,
-    const std::vector<std::uint8_t>& expectedBuffer
-) {
+void test_buffer_equality(const TField &field, const std::vector<std::uint8_t> &expectedBuffer) {
     nil::marshalling::status_type status;
     std::vector<unsigned char> outDataBuf = nil::marshalling::pack(field, status);
 
@@ -62,10 +59,8 @@ void test_buffer_equality(
 }
 
 template<typename TField>
-void test_round_trip(
-    const TField &field,
-    nil::marshalling::status_type expectedStatus = nil::marshalling::status_type::success
-) {
+void test_round_trip(const TField &field,
+                     nil::marshalling::status_type expectedStatus = nil::marshalling::status_type::success) {
     nil::marshalling::status_type status;
     std::vector<char> outDataBuf = nil::marshalling::pack(field, status);
 
@@ -79,24 +74,15 @@ void test_round_trip(
     BOOST_CHECK(field.value() == newField.value());
 }
 
-
 BOOST_AUTO_TEST_SUITE(bitfield_test_suite)
 
 BOOST_AUTO_TEST_CASE(test_0) {
     using integral_type_0 = integral_type<512>;
     using integral_type_1 = integral_type<512>;
-    using BitfieldMembers =
-        std::tuple<
-            integral_type_0,
-            integral_type_1
-        >;
+    using BitfieldMembers = std::tuple<integral_type_0, integral_type_1>;
     using testing_type =
-        nil::crypto3::marshalling::types::bitfield<
-            nil::marshalling::field_type<
-                nil::marshalling::option::big_endian
-            >,
-            BitfieldMembers
-        >;
+        nil::crypto3::marshalling::types::bitfield<nil::marshalling::field_type<nil::marshalling::option::big_endian>,
+                                                   BitfieldMembers>;
 
     static_assert(!testing_type::is_version_dependent(), "Invalid version dependency assumption");
 
@@ -151,23 +137,13 @@ BOOST_AUTO_TEST_CASE(test_0) {
 //     test_round_trip(field);
 // }
 
-
-
 BOOST_AUTO_TEST_CASE(test_2) {
     using integral_type_0 = integral_type<1, 1024, false, nil::marshalling::option::little_endian>;
     using integral_type_1 = integral_type<511, 1024, false, nil::marshalling::option::little_endian>;
-    using BitfieldMembers =
-        std::tuple<
-            integral_type_0,
-            integral_type_1
-        >;
+    using BitfieldMembers = std::tuple<integral_type_0, integral_type_1>;
     using testing_type =
-        nil::crypto3::marshalling::types::bitfield<
-            nil::marshalling::field_type<
-                nil::marshalling::option::big_endian
-            >,
-            BitfieldMembers
-        >;
+        nil::crypto3::marshalling::types::bitfield<nil::marshalling::field_type<nil::marshalling::option::big_endian>,
+                                                   BitfieldMembers>;
 
     testing_type field;
     static_cast<void>(field);
@@ -201,26 +177,18 @@ BOOST_AUTO_TEST_CASE(test_3) {
     using integral_type_8 = integral_type<10, 12, false, nil::marshalling::option::big_endian>;
     using integral_type_9 = integral_type<10, 321, false, nil::marshalling::option::little_endian>;
 
-    using BitfieldMembers =
-        std::tuple<
-            integral_type_0,
-            integral_type_1,
-            integral_type_2,
-            integral_type_3,
-            integral_type_4,
-            integral_type_5,
-            integral_type_6,
-            integral_type_7,
-            integral_type_8,
-            integral_type_9
-        >;
-    using testing_type =
-        nil::crypto3::marshalling::types::bitfield<
-            nil::marshalling::field_type<
-                nil::marshalling::option::little_endian
-            >,
-            BitfieldMembers
-        >;
+    using BitfieldMembers = std::tuple<integral_type_0,
+                                       integral_type_1,
+                                       integral_type_2,
+                                       integral_type_3,
+                                       integral_type_4,
+                                       integral_type_5,
+                                       integral_type_6,
+                                       integral_type_7,
+                                       integral_type_8,
+                                       integral_type_9>;
+    using testing_type = nil::crypto3::marshalling::types::
+        bitfield<nil::marshalling::field_type<nil::marshalling::option::little_endian>, BitfieldMembers>;
 
     testing_type field;
     static_cast<void>(field);
@@ -268,41 +236,27 @@ BOOST_AUTO_TEST_CASE(test_bitfield_endianness) {
     using integral_type_1 = integral_type<16, 16, false, nil::marshalling::option::big_endian>;
     using integral_type_2 = integral_type<5, 5, false, nil::marshalling::option::big_endian>;
 
-    using BitfieldMembers =
-        std::tuple<
-            integral_type_0,
-            integral_type_1,
-            integral_type_2
-        >;
+    using BitfieldMembers = std::tuple<integral_type_0, integral_type_1, integral_type_2>;
     using testing_type_big_endian =
-        nil::crypto3::marshalling::types::bitfield<
-            nil::marshalling::field_type<
-                nil::marshalling::option::big_endian
-            >,
-            BitfieldMembers
-        >;
+        nil::crypto3::marshalling::types::bitfield<nil::marshalling::field_type<nil::marshalling::option::big_endian>,
+                                                   BitfieldMembers>;
 
     testing_type_big_endian big_endian_field;
     static_cast<void>(big_endian_field);
 
-    auto& members_be = big_endian_field.value();
+    auto &members_be = big_endian_field.value();
     std::get<0>(members_be).value() = 0b000;
     std::get<1>(members_be).value() = 0b1110110100000001;
     std::get<2>(members_be).value() = 0b00000;
 
     test_buffer_equality(big_endian_field, {0b00000111, 0b01101000, 0b00001000});
 
-    using testing_type_little_endian =
-        nil::crypto3::marshalling::types::bitfield<
-            nil::marshalling::field_type<
-                nil::marshalling::option::little_endian
-            >,
-            BitfieldMembers
-        >;
+    using testing_type_little_endian = nil::crypto3::marshalling::types::
+        bitfield<nil::marshalling::field_type<nil::marshalling::option::little_endian>, BitfieldMembers>;
 
     testing_type_little_endian little_endian_field;
 
-    auto& members_le = little_endian_field.value();
+    auto &members_le = little_endian_field.value();
     std::get<0>(members_le).value() = 0b000;
     std::get<1>(members_le).value() = 0b1110110100000001;
     std::get<2>(members_le).value() = 0b00000;
@@ -318,24 +272,15 @@ BOOST_AUTO_TEST_CASE(test_inner_field_endianness) {
     using integral_type_1 = integral_type<16, 16, false, nil::marshalling::option::little_endian>;
     using integral_type_2 = integral_type<5, 5, false, nil::marshalling::option::big_endian>;
 
-    using BitfieldMembers =
-        std::tuple<
-            integral_type_0,
-            integral_type_1,
-            integral_type_2
-        >;
+    using BitfieldMembers = std::tuple<integral_type_0, integral_type_1, integral_type_2>;
     using testing_type_big_endian =
-        nil::crypto3::marshalling::types::bitfield<
-            nil::marshalling::field_type<
-                nil::marshalling::option::big_endian
-            >,
-            BitfieldMembers
-        >;
+        nil::crypto3::marshalling::types::bitfield<nil::marshalling::field_type<nil::marshalling::option::big_endian>,
+                                                   BitfieldMembers>;
 
     testing_type_big_endian big_endian_field;
     static_cast<void>(big_endian_field);
 
-    auto& members_be = big_endian_field.value();
+    auto &members_be = big_endian_field.value();
     std::get<0>(members_be).value() = 0b000;
     std::get<1>(members_be).value() = 0b1110110100000001;
     std::get<2>(members_be).value() = 0b00000;

--- a/test/bitfield.cpp
+++ b/test/bitfield.cpp
@@ -1,0 +1,346 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2018-2021 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2020-2021 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE crypto3_marshalling_bitwise_test
+
+#include <iostream>
+#include <iomanip>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
+#include <nil/crypto3/multiprecision/cpp_int.hpp>
+#include <nil/crypto3/multiprecision/number.hpp>
+#include <nil/marshalling/algorithms/pack.hpp>
+#include <nil/marshalling/endianness.hpp>
+#include <nil/marshalling/field_type.hpp>
+#include <nil/marshalling/status_type.hpp>
+
+#include <nil/crypto3/marshalling/multiprecision/processing/size_to_type.hpp>
+#include <nil/crypto3/marshalling/multiprecision/types/bitfield.hpp>
+#include "utils.h"
+
+
+template <size_t FixedBitLength, size_t BaseTypeBitLength = 1024, bool IsSigned = false, typename Endianness = nil::marshalling::option::big_endian>
+using integral_type =
+    nil::crypto3::marshalling::types::integral<
+        nil::marshalling::field_type<Endianness>,
+        typename nil::crypto3::marshalling::processing::size_to_type<BaseTypeBitLength, IsSigned>::type,
+        nil::marshalling::option::fixed_bit_length<FixedBitLength>
+    >;
+
+template<typename TField>
+void test_buffer_equality(
+    const TField &field,
+    const std::vector<std::uint8_t>& expectedBuffer
+) {
+    nil::marshalling::status_type status;
+    std::vector<unsigned char> outDataBuf = nil::marshalling::pack(field, status);
+
+    BOOST_CHECK(std::equal(expectedBuffer.begin(), expectedBuffer.end(), outDataBuf.begin()));
+}
+
+template<typename TField>
+void test_round_trip(
+    const TField &field,
+    nil::marshalling::status_type expectedStatus = nil::marshalling::status_type::success
+) {
+    nil::marshalling::status_type status;
+    std::vector<char> outDataBuf = nil::marshalling::pack(field, status);
+
+    std::cout << "final blob: ";
+    print_byteblob(outDataBuf.begin(), outDataBuf.end());
+
+    TField newField = nil::marshalling::pack<TField>(outDataBuf, status);
+
+    BOOST_CHECK(status == expectedStatus);
+    BOOST_CHECK(field == newField);
+    BOOST_CHECK(field.value() == newField.value());
+}
+
+
+BOOST_AUTO_TEST_SUITE(bitfield_test_suite)
+
+BOOST_AUTO_TEST_CASE(test_0) {
+    using integral_type_0 = integral_type<512>;
+    using integral_type_1 = integral_type<512>;
+    using BitfieldMembers =
+        std::tuple<
+            integral_type_0,
+            integral_type_1
+        >;
+    using testing_type =
+        nil::crypto3::marshalling::types::bitfield<
+            nil::marshalling::field_type<
+                nil::marshalling::option::big_endian
+            >,
+            BitfieldMembers
+        >;
+
+    static_assert(!testing_type::is_version_dependent(), "Invalid version dependency assumption");
+
+    testing_type field;
+    static_cast<void>(field);
+
+    BOOST_CHECK(field.length() == 128U);
+    BOOST_CHECK(field.member_bit_length<0>() == 512U);
+    BOOST_CHECK(field.member_bit_length<1>() == 512U);
+
+    auto &members = field.value();
+    auto &mem1 = std::get<0>(members);
+    mem1.value() = 0x1;
+    BOOST_CHECK(mem1.value() == 0x1);
+    auto &mem2 = std::get<1>(members);
+    mem2.value() = 0xABCDEF1234567890;
+    BOOST_CHECK(mem2.value() == 0xABCDEF1234567890);
+
+    test_round_trip(field);
+}
+
+// Doesn't work, signed values serialization is unsupported
+// BOOST_AUTO_TEST_CASE(test_1) {
+//     using integral_type_0 = integral_type<5, 128, /*IsSigned=*/ true>;
+//     using integral_type_1 = integral_type<3, 256, /*IsSigned=*/ true>;
+//     using BitfieldMembers =
+//         std::tuple<
+//             integral_type_0,
+//             integral_type_1
+//         >;
+//     using testing_type =
+//         nil::crypto3::marshalling::types::bitfield<
+//             nil::marshalling::field_type<
+//                 nil::marshalling::option::big_endian
+//             >,
+//             BitfieldMembers
+//         >;
+
+//     testing_type field;
+//     static_cast<void>(field);
+//     BOOST_CHECK(field.length() == 1U);
+//     BOOST_CHECK(field.member_bit_length<0>() == 5U);
+//     BOOST_CHECK(field.member_bit_length<1>() == 3U);
+
+//     auto &members = field.value();
+//     auto &mem1 = std::get<0>(members);
+//     auto &mem2 = std::get<1>(members);
+//     mem1.value() = -0x7;
+//     mem2.value() = -0x2;
+//     BOOST_CHECK(mem1.value() == -0x7);
+//     BOOST_CHECK(mem2.value() == -0x2);
+//     test_round_trip(field);
+// }
+
+
+
+BOOST_AUTO_TEST_CASE(test_2) {
+    using integral_type_0 = integral_type<1, 1024, false, nil::marshalling::option::little_endian>;
+    using integral_type_1 = integral_type<511, 1024, false, nil::marshalling::option::little_endian>;
+    using BitfieldMembers =
+        std::tuple<
+            integral_type_0,
+            integral_type_1
+        >;
+    using testing_type =
+        nil::crypto3::marshalling::types::bitfield<
+            nil::marshalling::field_type<
+                nil::marshalling::option::big_endian
+            >,
+            BitfieldMembers
+        >;
+
+    testing_type field;
+    static_cast<void>(field);
+
+    BOOST_CHECK(field.length() == 64U);
+    BOOST_CHECK(field.member_bit_length<0>() == 1U);
+    BOOST_CHECK(field.member_bit_length<1>() == 511U);
+
+    auto &members = field.value();
+    auto &mem1 = std::get<0>(members);
+    mem1.value() = 0x1;
+    BOOST_CHECK(mem1.value() == 0x1);
+    auto &mem2 = std::get<1>(members);
+    nil::crypto3::multiprecision::uint1024_t max_val = 1;
+    max_val = (max_val << 511) - 1;
+    mem2.value() = max_val;
+    BOOST_CHECK(mem2.value() == max_val);
+
+    test_round_trip(field);
+}
+
+BOOST_AUTO_TEST_CASE(test_3) {
+    using integral_type_0 = integral_type<2, 123, false, nil::marshalling::option::big_endian>;
+    using integral_type_1 = integral_type<3, 124, false, nil::marshalling::option::little_endian>;
+    using integral_type_2 = integral_type<4, 125, false, nil::marshalling::option::little_endian>;
+    using integral_type_3 = integral_type<5, 126, false, nil::marshalling::option::big_endian>;
+    using integral_type_4 = integral_type<6, 127, false, nil::marshalling::option::big_endian>;
+    using integral_type_5 = integral_type<7, 128, false, nil::marshalling::option::big_endian>;
+    using integral_type_6 = integral_type<8, 129, false, nil::marshalling::option::little_endian>;
+    using integral_type_7 = integral_type<9, 130, false, nil::marshalling::option::little_endian>;
+    using integral_type_8 = integral_type<10, 12, false, nil::marshalling::option::big_endian>;
+    using integral_type_9 = integral_type<10, 321, false, nil::marshalling::option::little_endian>;
+
+    using BitfieldMembers =
+        std::tuple<
+            integral_type_0,
+            integral_type_1,
+            integral_type_2,
+            integral_type_3,
+            integral_type_4,
+            integral_type_5,
+            integral_type_6,
+            integral_type_7,
+            integral_type_8,
+            integral_type_9
+        >;
+    using testing_type =
+        nil::crypto3::marshalling::types::bitfield<
+            nil::marshalling::field_type<
+                nil::marshalling::option::little_endian
+            >,
+            BitfieldMembers
+        >;
+
+    testing_type field;
+    static_cast<void>(field);
+
+    BOOST_CHECK(field.length() == 8U);
+    BOOST_CHECK(field.member_bit_length<0>() == 2U);
+    BOOST_CHECK(field.member_bit_length<1>() == 3U);
+    BOOST_CHECK(field.member_bit_length<2>() == 4U);
+    BOOST_CHECK(field.member_bit_length<3>() == 5U);
+    BOOST_CHECK(field.member_bit_length<4>() == 6U);
+    BOOST_CHECK(field.member_bit_length<5>() == 7U);
+    BOOST_CHECK(field.member_bit_length<6>() == 8U);
+    BOOST_CHECK(field.member_bit_length<7>() == 9U);
+    BOOST_CHECK(field.member_bit_length<8>() == 10U);
+    BOOST_CHECK(field.member_bit_length<9>() == 10U);
+
+    auto &members = field.value();
+    std::get<0>(members).value() = 0x0;
+    std::get<1>(members).value() = 0x1;
+    std::get<2>(members).value() = 0x2;
+    std::get<3>(members).value() = 0x3;
+    std::get<4>(members).value() = 0x4;
+    std::get<5>(members).value() = 0x5;
+    std::get<6>(members).value() = 0x6;
+    std::get<7>(members).value() = 0x7;
+    std::get<8>(members).value() = 0x8;
+    std::get<9>(members).value() = 0x9;
+
+    test_round_trip(field);
+
+    BOOST_CHECK(std::get<0>(members).value() == 0x0);
+    BOOST_CHECK(std::get<1>(members).value() == 0x1);
+    BOOST_CHECK(std::get<2>(members).value() == 0x2);
+    BOOST_CHECK(std::get<3>(members).value() == 0x3);
+    BOOST_CHECK(std::get<4>(members).value() == 0x4);
+    BOOST_CHECK(std::get<5>(members).value() == 0x5);
+    BOOST_CHECK(std::get<6>(members).value() == 0x6);
+    BOOST_CHECK(std::get<7>(members).value() == 0x7);
+    BOOST_CHECK(std::get<8>(members).value() == 0x8);
+    BOOST_CHECK(std::get<9>(members).value() == 0x9);
+}
+
+BOOST_AUTO_TEST_CASE(test_bitfield_endianness) {
+    using integral_type_0 = integral_type<3, 3, false, nil::marshalling::option::big_endian>;
+    using integral_type_1 = integral_type<16, 16, false, nil::marshalling::option::big_endian>;
+    using integral_type_2 = integral_type<5, 5, false, nil::marshalling::option::big_endian>;
+
+    using BitfieldMembers =
+        std::tuple<
+            integral_type_0,
+            integral_type_1,
+            integral_type_2
+        >;
+    using testing_type_big_endian =
+        nil::crypto3::marshalling::types::bitfield<
+            nil::marshalling::field_type<
+                nil::marshalling::option::big_endian
+            >,
+            BitfieldMembers
+        >;
+
+    testing_type_big_endian big_endian_field;
+    static_cast<void>(big_endian_field);
+
+    auto& members_be = big_endian_field.value();
+    std::get<0>(members_be).value() = 0b000;
+    std::get<1>(members_be).value() = 0b1110110100000001;
+    std::get<2>(members_be).value() = 0b00000;
+
+    test_buffer_equality(big_endian_field, {0b00000111, 0b01101000, 0b00001000});
+
+    using testing_type_little_endian =
+        nil::crypto3::marshalling::types::bitfield<
+            nil::marshalling::field_type<
+                nil::marshalling::option::little_endian
+            >,
+            BitfieldMembers
+        >;
+
+    testing_type_little_endian little_endian_field;
+
+    auto& members_le = little_endian_field.value();
+    std::get<0>(members_le).value() = 0b000;
+    std::get<1>(members_le).value() = 0b1110110100000001;
+    std::get<2>(members_le).value() = 0b00000;
+
+    test_buffer_equality(little_endian_field, {0b00001000, 0b01101000, 0b00000111});
+
+    test_round_trip(little_endian_field);
+}
+
+BOOST_AUTO_TEST_CASE(test_inner_field_endianness) {
+    using integral_type_0 = integral_type<3, 3, false, nil::marshalling::option::big_endian>;
+    // XXX: inner endianness does not affect serialization. Upstream bitfield does not do this neither
+    using integral_type_1 = integral_type<16, 16, false, nil::marshalling::option::little_endian>;
+    using integral_type_2 = integral_type<5, 5, false, nil::marshalling::option::big_endian>;
+
+    using BitfieldMembers =
+        std::tuple<
+            integral_type_0,
+            integral_type_1,
+            integral_type_2
+        >;
+    using testing_type_big_endian =
+        nil::crypto3::marshalling::types::bitfield<
+            nil::marshalling::field_type<
+                nil::marshalling::option::big_endian
+            >,
+            BitfieldMembers
+        >;
+
+    testing_type_big_endian big_endian_field;
+    static_cast<void>(big_endian_field);
+
+    auto& members_be = big_endian_field.value();
+    std::get<0>(members_be).value() = 0b000;
+    std::get<1>(members_be).value() = 0b1110110100000001;
+    std::get<2>(members_be).value() = 0b00000;
+
+    test_buffer_equality(big_endian_field, {0b00000111, 0b01101000, 0b00001000});
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/integral.cpp
+++ b/test/integral.cpp
@@ -218,31 +218,4 @@ BOOST_AUTO_TEST_CASE(integral_cpp_int_backend_23_bits) {
         23, 23, nil::crypto3::multiprecision::unsigned_magnitude, nil::crypto3::multiprecision::checked, void>>, bool>();
 }
 
-BOOST_AUTO_TEST_CASE(integral_cpp_int_backend_123_bits) {
-    using signed_type = nil::crypto3::multiprecision::number<nil::crypto3::multiprecision::cpp_int_backend<
-        123, 123, nil::crypto3::multiprecision::signed_magnitude, nil::crypto3::multiprecision::unchecked, void>>;
-    std::cout << std::hex;
-    std::cerr << std::hex;
-    for (unsigned i = 0; i < 1000; ++i) {
-        signed_type val = generate_random<signed_type, true>();
-        nil::marshalling::status_type status;
-        std::vector<std::uint8_t> cv = nil::marshalling::pack<nil::marshalling::option::big_endian>(val, status);
-        signed_type new_val = nil::marshalling::pack<nil::marshalling::option::big_endian>(cv, status);
-        BOOST_CHECK(new_val == val);
-        std::cout << val << std::endl;
-        print_byteblob(std::begin(cv), std::end(cv));
-        // T test_val = nil::marshalling::pack<nil::marshalling::option::big_endian>(cv, status);
-        // test_round_trip_fixed_precision_little_endian<signed_type, unsigned char>(val);
-    }
-
-
-
-    // BOOST_CHECK(val == test_val);
-    // BOOST_CHECK(status == nil::marshalling::status_type::success);
-
-    // std::vector<unit_type> test_cv = nil::marshalling::pack<nil::marshalling::option::big_endian>(val, status);
-    // test_round_trip_fixed_precision<nil::crypto3::multiprecision::number<nil::crypto3::multiprecision::cpp_int_backend<
-    //     123, 123, nil::crypto3::multiprecision::unsigned_magnitude, nil::crypto3::multiprecision::checked, void>>, bool>();
-}
-
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/integral_fixed_size_container.cpp
+++ b/test/integral_fixed_size_container.cpp
@@ -27,8 +27,6 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int.hpp>
 #include <iostream>
 #include <iomanip>
 #include <type_traits>
@@ -45,50 +43,8 @@
 #include <nil/marshalling/algorithms/pack.hpp>
 
 #include <nil/crypto3/marshalling/multiprecision/types/integral.hpp>
+#include "utils.h"
 
-template<class T>
-struct unchecked_type {
-    typedef T type;
-};
-
-template<unsigned MinBits, unsigned MaxBits, nil::crypto3::multiprecision::cpp_integer_type SignType,
-         nil::crypto3::multiprecision::cpp_int_check_type Checked, class Allocator,
-         nil::crypto3::multiprecision::expression_template_option ExpressionTemplates>
-struct unchecked_type<nil::crypto3::multiprecision::number<
-    nil::crypto3::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>,
-    ExpressionTemplates>> {
-    typedef nil::crypto3::multiprecision::number<
-        nil::crypto3::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType,
-                                                      nil::crypto3::multiprecision::unchecked, Allocator>,
-        ExpressionTemplates>
-        type;
-};
-
-template<class T>
-T generate_random() {
-    typedef typename unchecked_type<T>::type unchecked_T;
-
-    static const unsigned limbs = std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_bounded ?
-                                      std::numeric_limits<T>::digits / std::numeric_limits<unsigned>::digits + 3 :
-                                      20;
-
-    static boost::random::uniform_int_distribution<unsigned> ui(0, limbs);
-    static boost::random::mt19937 gen;
-    unchecked_T val = gen();
-    unsigned lim = ui(gen);
-    for (unsigned i = 0; i < lim; ++i) {
-        val *= (gen.max)();
-        val += gen();
-    }
-    return val;
-}
-
-template<typename TIter>
-void print_byteblob(TIter iter_begin, TIter iter_end) {
-    for (TIter it = iter_begin; it != iter_end; it++) {
-        std::cout << std::hex << int(*it) << std::endl;
-    }
-}
 
 template<class T, std::size_t TSize, typename OutputType>
 void test_round_trip_fixed_size_container_fixed_precision_big_endian(
@@ -119,13 +75,13 @@ void test_round_trip_fixed_size_container_fixed_precision_big_endian(
     }
 
     nil::marshalling::status_type status;
-    std::array<T, TSize> test_val = 
+    std::array<T, TSize> test_val =
         nil::marshalling::pack<nil::marshalling::option::big_endian>(cv, status);
 
     BOOST_CHECK(std::equal(val_container.begin(), val_container.end(), test_val.begin()));
     BOOST_CHECK(status == nil::marshalling::status_type::success);
 
-    std::vector<unit_type> test_cv = 
+    std::vector<unit_type> test_cv =
         nil::marshalling::pack<nil::marshalling::option::big_endian>(val_container, status);
 
     BOOST_CHECK(std::equal(test_cv.begin(), test_cv.end(), cv.begin()));
@@ -157,13 +113,13 @@ void test_round_trip_fixed_size_container_fixed_precision_little_endian(
     }
 
     nil::marshalling::status_type status;
-    std::array<T, TSize> test_val = 
+    std::array<T, TSize> test_val =
         nil::marshalling::pack<nil::marshalling::option::little_endian>(cv, status);
 
     BOOST_CHECK(std::equal(val_container.begin(), val_container.end(), test_val.begin()));
     BOOST_CHECK(status == nil::marshalling::status_type::success);
 
-    std::vector<unit_type> test_cv = 
+    std::vector<unit_type> test_cv =
         nil::marshalling::pack<nil::marshalling::option::little_endian>(val_container, status);
 
     BOOST_CHECK(std::equal(test_cv.begin(), test_cv.end(), cv.begin()));

--- a/test/integral_non_fixed_size_container.cpp
+++ b/test/integral_non_fixed_size_container.cpp
@@ -32,38 +32,15 @@
 #include <iostream>
 #include <iomanip>
 
-#include <nil/marshalling/status_type.hpp>
-#include <nil/marshalling/endianness.hpp>
-
+#include <nil/crypto3/marshalling/multiprecision/types/integral.hpp>
 #include <nil/crypto3/multiprecision/cpp_int.hpp>
 #include <nil/crypto3/multiprecision/number.hpp>
-
 #include <nil/marshalling/algorithms/pack.hpp>
+#include <nil/marshalling/endianness.hpp>
+#include <nil/marshalling/status_type.hpp>
 
-#include <nil/crypto3/marshalling/multiprecision/types/integral.hpp>
 #include "utils.h"
 
-
-template<class T>
-struct unchecked_type {
-    typedef T type;
-};
-
-template<unsigned MinBits,
-         unsigned MaxBits,
-         nil::crypto3::multiprecision::cpp_integer_type SignType,
-         nil::crypto3::multiprecision::cpp_int_check_type Checked,
-         class Allocator,
-         nil::crypto3::multiprecision::expression_template_option ExpressionTemplates>
-struct unchecked_type<nil::crypto3::multiprecision::number<
-    nil::crypto3::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>,
-    ExpressionTemplates>> {
-    typedef nil::crypto3::multiprecision::number<
-        nil::crypto3::multiprecision::
-            cpp_int_backend<MinBits, MaxBits, SignType, nil::crypto3::multiprecision::unchecked, Allocator>,
-        ExpressionTemplates>
-        type;
-};
 
 template<typename Endianness, class T, std::size_t TSize, typename OutputType>
 void test_round_trip_non_fixed_size_container_fixed_precision(std::vector<T>

--- a/test/integral_non_fixed_size_container.cpp
+++ b/test/integral_non_fixed_size_container.cpp
@@ -41,6 +41,8 @@
 #include <nil/marshalling/algorithms/pack.hpp>
 
 #include <nil/crypto3/marshalling/multiprecision/types/integral.hpp>
+#include "utils.h"
+
 
 template<class T>
 struct unchecked_type {
@@ -63,32 +65,6 @@ struct unchecked_type<nil::crypto3::multiprecision::number<
         type;
 };
 
-template<class T>
-T generate_random() {
-    typedef typename unchecked_type<T>::type unchecked_T;
-
-    static const unsigned limbs = std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_bounded ?
-                                      std::numeric_limits<T>::digits / std::numeric_limits<unsigned>::digits + 3 :
-                                      20;
-
-    static boost::random::uniform_int_distribution<unsigned> ui(0, limbs);
-    static boost::random::mt19937 gen;
-    unchecked_T val = gen();
-    unsigned lim = ui(gen);
-    for (unsigned i = 0; i < lim; ++i) {
-        val *= (gen.max)();
-        val += gen();
-    }
-    return val;
-}
-
-template<typename TIter>
-void print_byteblob(TIter iter_begin, TIter iter_end) {
-    for (TIter it = iter_begin; it != iter_end; it++) {
-        std::cout << std::hex << int(*it) << std::endl;
-    }
-}
-
 template<typename Endianness, class T, std::size_t TSize, typename OutputType>
 void test_round_trip_non_fixed_size_container_fixed_precision(std::vector<T>
                                                                   val_container) {
@@ -96,7 +72,7 @@ void test_round_trip_non_fixed_size_container_fixed_precision(std::vector<T>
     using unit_type = OutputType;
 
     nil::marshalling::status_type status;
-    std::vector<unit_type> cv = 
+    std::vector<unit_type> cv =
         nil::marshalling::pack<Endianness>(val_container, status);
 
 
@@ -106,7 +82,7 @@ void test_round_trip_non_fixed_size_container_fixed_precision(std::vector<T>
 
     BOOST_CHECK(std::equal(val_container.begin(), val_container.end(), test_val.begin()));
     BOOST_CHECK(status == nil::marshalling::status_type::success);
-    
+
 }
 
 template<typename Endianness, class T, std::size_t TSize, typename OutputType>

--- a/test/utils.h
+++ b/test/utils.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int.hpp>
+
+#include <nil/crypto3/multiprecision/cpp_int.hpp>
+#include <nil/crypto3/multiprecision/number.hpp>
+
+
+template<class T>
+struct unchecked_type {
+    typedef T type;
+};
+
+template<unsigned MinBits, unsigned MaxBits, nil::crypto3::multiprecision::cpp_integer_type SignType,
+         nil::crypto3::multiprecision::cpp_int_check_type Checked, class Allocator,
+         nil::crypto3::multiprecision::expression_template_option ExpressionTemplates>
+struct unchecked_type<nil::crypto3::multiprecision::number<
+    nil::crypto3::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>,
+    ExpressionTemplates>> {
+    typedef nil::crypto3::multiprecision::number<
+        nil::crypto3::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType,
+                                                      nil::crypto3::multiprecision::unchecked, Allocator>,
+        ExpressionTemplates>
+        type;
+};
+
+template<class T, bool GenerateSigned = false>
+T generate_random() {
+    typedef typename unchecked_type<T>::type unchecked_T;
+
+    static const unsigned limbs = std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_bounded ?
+                                      std::numeric_limits<T>::digits / std::numeric_limits<unsigned>::digits + 3 :
+                                      20;
+
+    static boost::random::uniform_int_distribution<unsigned> ui(0, limbs);
+    static boost::random::mt19937 gen;
+    unchecked_T val = gen();
+    unsigned lim = ui(gen);
+    for (unsigned i = 0; i < lim; ++i) {
+        val *= (gen.max)();
+        val += gen();
+    }
+
+    if (std::numeric_limits<T>::is_signed) {
+        static boost::random::uniform_int_distribution<int> sign_gen(-1, 1);
+        int sign = sign_gen(gen);
+        val *= sign;
+    }
+
+    return static_cast<T>(val);
+}
+
+template<typename TIter>
+void print_byteblob(TIter iter_begin, TIter iter_end) {
+    for (TIter it = iter_begin; it != iter_end; ++it) {
+        std::cout << "0x"
+                  << std::hex << std::setw(2) << std::setfill('0')
+                  << static_cast<int>(static_cast<unsigned char>(*it)) << " ";
+    }
+    std::cout << std::endl;
+}

--- a/test/utils.h
+++ b/test/utils.h
@@ -42,7 +42,7 @@ T generate_random() {
         val += gen();
     }
 
-    if (std::numeric_limits<T>::is_signed) {
+    if (GenerateSigned && std::numeric_limits<T>::is_signed) {
         static boost::random::uniform_int_distribution<int> sign_gen(-1, 1);
         int sign = sign_gen(gen);
         val *= sign;


### PR DESCRIPTION
Current PR adds a specification for `fixed_bit_length`, so it could be used with underlying multiprecision unsigned integer instead of basic uint types to overcome limitations on type size (core lib allows only 64 bits max bitfield length, 32 bits max length for inner types)